### PR TITLE
Fix extra hash of scrape yaml of hero status

### DIFF
--- a/data/heroes_ability.yml
+++ b/data/heroes_ability.yml
@@ -1,0 +1,97 @@
+---
+- :name: Rona
+  :ability:
+  - - :name: Berserkers' Fury
+  - - :name: Into the Fray
+  - - :name: Foesplitter
+  - - :name: Red Mist
+- :name: Fortress
+  :ability:
+  - - :name: Packmates
+  - - :name: Truth of the Tooth
+  - - :name: Law of the Claw
+  - - :name: Attack of the Pack
+- :name: Joule
+  :ability:
+  - - :name: Heavy Plating
+  - - :name: Rocket Leap
+  - - :name: Thunder Strike
+  - - :name: Big Red Button
+- :name: Ardan
+  :ability:
+  - - :name: Julia's Gift
+  - - :name: Vanguard
+  - - :name: Blood for Blood
+  - - :name: Gauntlet
+- :name: Skaarf
+  :ability:
+  - - :name: Fan the Flames
+  - - :name: Spitfire
+  - - :name: Goop
+  - - :name: Dragon Breath
+- :name: Taka
+  :ability:
+  - - :name: House Kamuha
+  - - :name: Kaiten
+  - - :name: Kaku
+  - - :name: X-Retsu
+- :name: Krul
+  :ability:
+  - - :name: Shadows Empower Me
+  - - :name: Dead Man's Rush
+  - - :name: Spectral Smite
+  - - :name: From Hell's Heart
+- :name: SAW
+  :ability:
+  - - :name: Spin Up
+  - - :name: Roadie Run
+  - - :name: Suppressing Fire
+  - - :name: Mad Cannon
+- :name: Petal
+  :ability:
+  - - :name: Bramblethorn Munions
+  - - :name: Bramblethorn Seed
+  - - :name: Yay, Pets!
+  - - :name: Spontaneous Combustion
+- :name: Glaive
+  :ability:
+  - - :name: Hunt the Weak
+  - - :name: Afterburn
+  - - :name: Twisted Stroke
+  - - :name: Bloodsong
+- :name: Koshka
+  :ability:
+  - - :name: Bloodrush
+  - - :name: Pouncy Fun
+  - - :name: Twirly Death
+  - - :name: Yummy Catnip Frenzy
+- :name: Adagio
+  :ability:
+  - - :name: Arcane Renewal
+  - - :name: Gift of Fire
+  - - :name: Agent of Wrath
+  - - :name: Verse of Judgement
+- :name: Ringo
+  :ability:
+  - - :name: Double Down
+  - - :name: Achilles Shot
+  - - :name: Twirling Silver
+  - - :name: Hellfire Brew
+- :name: Catherine
+  :ability:
+  - - :name: Captain of the Guard
+  - - :name: Merciless Pursuit
+  - - :name: Stormguard
+  - - :name: Blast Tremor
+- :name: Celeste
+  :ability:
+  - - :name: Julia's Light
+  - - :name: Heliogenesis
+  - - :name: Core Collapse
+  - - :name: Solar Storm
+- :name: Vox
+  :ability:
+  - - :name: Julia's Song
+  - - :name: Sonic Zoom
+  - - :name: Pulse
+  - - :name: Wait for It

--- a/lib/vainglory/scrape/ability.rb
+++ b/lib/vainglory/scrape/ability.rb
@@ -1,15 +1,16 @@
 module Vainglory
   class Ability
+    def initialize(name, effect)
+      @name = name
+      @effect = effect
+    end
+
     attr_accessor :name, :effect
 
     def to_hash
-      array = []
-      instance_variables.each do |variable|
-        key = variable.to_s.tr('@', '')
-        value = instance_variable_get(variable)
-        array.push({key.to_sym => value})
-      end
-      array
+      hash = Hash.new
+      hash.store(@name.to_sym, @effect)
+      hash
     end
   end
 end

--- a/lib/vainglory/scrape/scrape_hero_from_official.rb
+++ b/lib/vainglory/scrape/scrape_hero_from_official.rb
@@ -30,12 +30,12 @@ module Vainglory
       status_array = []
       # h6とh4の子孫要素を持つdivを取得
       @doc.xpath("//div[@id='stats-wrapper']//div[h6 and h4]").each do |status_div|
-        status = Vainglory::Status.new
-        status.name = status_div.css("h6").text
-
+        status_name = status_div.css("h6").text
         status_str = status_div.css("h4").text.strip
-        status.start = get_float_from_match(status_str.match(/\d+(?:.\d+)?/))
-        status.glow = get_float_from_match(status_str.match(/\((\+\d+(?:\.\d+)?)\)/))
+        status_start = get_float_from_match(status_str.match(/\d+(?:.\d+)?/))
+        status_glow = get_float_from_match(status_str.match(/\((\+\d+(?:\.\d+)?)\)/))
+        status = Vainglory::Status.new(status_name, status_start, status_glow)
+
         status_array.push(status)
       end
       @statuses = status_array
@@ -44,15 +44,16 @@ module Vainglory
     def get_ability
       ability_array = []
       @doc.css("div.ability").xpath("./div[@class='text' and p[@class='mb0 md-show']]").each do |ability_div|
-        ability = Vainglory::Ability.new
-        ability.name = ability_div.css("h5.white").text
-        ability.effect = ability_div.css("p.mb0").text 
+        ability_name = ability_div.css("h5.white").text
+        ability_effect = ability_div.css("p.mb0").text 
+        ability = Vainglory::Ability.new(ability_name, ability_effect)
+
         ability_array.push(ability)
       end
       @abilities = ability_array
     end
 
-    def to_hash
+    def to_hash(format=nil)
        status_array = []
        @statuses.each do |status|
          status_array.push(status.to_hash)
@@ -63,12 +64,19 @@ module Vainglory
          ability_array.push(ability.to_hash)
        end
 
-      {
-        name: @name,
-        #excerpt: @excerpt,
-        status: status_array#,
-        #ability: ability_array
-      }
+       case format
+       when nil
+         {
+           name: @name,
+           excerpt: @excerpt,
+           status: status_array,
+           ability: ability_array
+         }
+       when :status
+         hash = Hash.new
+         hash.store(@name.to_sym, status_array)
+         hash
+       end
     end
 
     private

--- a/lib/vainglory/scrape/scrape_hero_from_official.rb
+++ b/lib/vainglory/scrape/scrape_hero_from_official.rb
@@ -54,14 +54,14 @@ module Vainglory
     end
 
     def to_hash(format=nil)
-       status_array = []
+       status_hash = Hash.new
        @statuses.each do |status|
-         status_array.push(status.to_hash)
+         status_hash.merge!(status.to_hash)
        end
 
-       ability_array = []
+       ability_hash = Hash.new
        @abilities.each do |ability|
-         ability_array.push(ability.to_hash)
+         ability_hash.merge!(ability.to_hash)
        end
 
        case format
@@ -69,12 +69,12 @@ module Vainglory
          {
            name: @name,
            excerpt: @excerpt,
-           status: status_array,
-           ability: ability_array
+           status: status_hash,
+           ability: ability_hash
          }
        when :status
          hash = Hash.new
-         hash.store(@name.to_sym, status_array)
+         hash.store(@name.to_sym, status_hash)
          hash
        end
     end

--- a/lib/vainglory/scrape/status.rb
+++ b/lib/vainglory/scrape/status.rb
@@ -1,6 +1,6 @@
 module Vainglory
   class Status
-    def initialize(name=nil, start=nil, glow=nil)
+    def initialize(name, start, glow)
       @name = name
       @start = start
       @glow = glow

--- a/lib/vainglory/scrape/status.rb
+++ b/lib/vainglory/scrape/status.rb
@@ -1,9 +1,9 @@
 module Vainglory
   class Status
-    def initialize(name, start, glow)
-      name = name || nil
-      start = start || nil
-      glow = glow || nil
+    def initialize(name=nil, start=nil, glow=nil)
+      @name = name
+      @start = start
+      @glow = glow
     end
 
     attr_accessor :name, :start, :glow
@@ -46,13 +46,9 @@ module Vainglory
     end
 
     def to_hash
-      array = []
-      instance_variables.each do |variable|
-        key = variable.to_s.tr('@', '')
-        value = instance_variable_get(variable)
-        array.push({key.to_sym => value})
-      end
-      array
+      hash = Hash.new
+      hash.store(@name.to_sym, {start: @start, glow: @glow})
+      hash
     end
   end
 end

--- a/lib/vainglory/scrape/status.rb
+++ b/lib/vainglory/scrape/status.rb
@@ -1,9 +1,9 @@
 module Vainglory
   class Status
     def initialize(name, start, glow)
-      @name = name
-      @start = start
-      @glow = glow
+      self.name = name
+      self.start = start
+      self.glow = glow
     end
 
     attr_accessor :name, :start, :glow

--- a/lib/vainglory/scrape/status.rb
+++ b/lib/vainglory/scrape/status.rb
@@ -30,6 +30,10 @@ module Vainglory
         "attack_range"
       when "Movement Speed" then
         "move_speed"
+      when "" then
+        nil
+      else
+        status_name
       end
     end
 

--- a/lib/vainglory/scrape/status.rb
+++ b/lib/vainglory/scrape/status.rb
@@ -10,27 +10,27 @@ module Vainglory
 
     def self.convert_status_name(status_name)
       case status_name
-      when "ヒットポイント(HP)" then
+      when "ヒットポイント(HP)", "Hit Points(HP)"
         "hp"
-      when "HP再生" then
+      when "HP再生", "HP Regen"
         "hp_regen"
-      when "エナジーポイント(EP)" then
+      when "エナジーポイント(EP)", "Energy Points(EP)"
         "ep"
-      when "EP回復" then
+      when "EP回復", "EP Regen"
         "ep_regen"
-      when "武器ダメージ" then
+      when "武器ダメージ", "Weapon Damage"
         "weapon_damage"
-      when "攻撃速度" then
+      when "攻撃速度", "Attack Speed"
         "attack_speed"
-      when "アーマー" then
+      when "アーマー", "Armor"
         "armor"
-      when "シールド" then
+      when "シールド", "Shield"
         "shield"
-      when "攻撃範囲" then
+      when "攻撃範囲", "Attack Range"
         "attack_range"
-      when "Movement Speed" then
+      when "Movement Speed"
         "move_speed"
-      when "" then
+      when ""
         nil
       else
         status_name

--- a/lib/vainglory/scrape/status.rb
+++ b/lib/vainglory/scrape/status.rb
@@ -1,12 +1,12 @@
 module Vainglory
   class Status
-    def initialize
-      status = nil
-      start = nil
-      glow = nil
+    def initialize(name, start, glow)
+      name = name || nil
+      start = start || nil
+      glow = glow || nil
     end
 
-    attr_accessor :status, :start, :glow
+    attr_accessor :name, :start, :glow
 
     def self.convert_status_name(status_name)
       case status_name

--- a/script/scrape.rb
+++ b/script/scrape.rb
@@ -30,11 +30,11 @@ def main
     celeste: 'celeste/',
     vox: 'vox/'
   }
-  heroes = []
+  heroes = Hash.new
   hero_urls.each do |key, value| 
     hero_url = root_url + 'hero/' + value
     hero = Vainglory::ScrapeHeroFromOfficial.new(hero_url)
-    heroes.push(hero.to_hash)
+    heroes.merge!(hero.to_hash(:status))
   end
   yaml = YAML.dump(heroes)
   File.open(OUTPUT_YML_PATH, 'w') do |file|

--- a/test/vainglory/scrape/ability_test.rb
+++ b/test/vainglory/scrape/ability_test.rb
@@ -1,0 +1,21 @@
+require 'test_helper'
+require 'vainglory/scrape/ability'
+
+class AbilityTest < Minitest::Test
+  def test_initialize
+    ability = Vainglory::Ability.new("ケンカ上等", "飛びかかる")
+    assert_equal("ケンカ上等", ability.name)
+    assert_equal("飛びかかる", ability.effect)
+
+    assert_raises do
+      Vainglory::Ability.new("ケンカ上等")
+    end
+  end
+
+  def to_hash
+    ability = Vainglory::Ability.new(:into_the_fray, "飛びかかる")
+    actual = ability.to_hash
+    expected = {into_the_fray: {effect: "飛びかかる"}}
+    assert_equal(expected, actual)
+  end
+end

--- a/test/vainglory/scrape/status_test.rb
+++ b/test/vainglory/scrape/status_test.rb
@@ -3,11 +3,6 @@ require 'vainglory/scrape/status'
 
 class StatusTest < Minitest::Test
   def test_initialize
-    status = Vainglory::Status.new
-    assert_nil(status.name)
-    assert_nil(status.start)
-    assert_nil(status.glow)
-
     status = Vainglory::Status.new("hp", 100, 2)
     assert_equal("hp", status.name)
     assert_equal(100, status.start)

--- a/test/vainglory/scrape/status_test.rb
+++ b/test/vainglory/scrape/status_test.rb
@@ -3,7 +3,7 @@ require 'vainglory/scrape/status'
 
 class StatusTest < Minitest::Test
   def test_initialize
-    status = Vainglory::Status.new("hp", 100, 2)
+    status = Vainglory::Status.new("ヒットポイント(HP)", 100, 2)
     assert_equal("hp", status.name)
     assert_equal(100, status.start)
     assert_equal(2, status.glow)

--- a/test/vainglory/scrape/status_test.rb
+++ b/test/vainglory/scrape/status_test.rb
@@ -7,6 +7,13 @@ class StatusTest < Minitest::Test
     assert_equal("hp", status.name)
     assert_equal(100, status.start)
     assert_equal(2, status.glow)
+
+    assert_raises do
+      Vainglory::Status.new("hp")
+    end
+    assert_raises do
+      Vainglory::Status.new("hp", 100)
+    end
   end
 
   def test_convert_status_name

--- a/test/vainglory/scrape/status_test.rb
+++ b/test/vainglory/scrape/status_test.rb
@@ -22,22 +22,49 @@ class StatusTest < Minitest::Test
   def test_convert_status_name
     actual = Vainglory::Status.convert_status_name("ヒットポイント(HP)")
     assert_equal("hp", actual)
+    actual = Vainglory::Status.convert_status_name("Hit Points(HP)")
+    assert_equal("hp", actual)
+
     actual = Vainglory::Status.convert_status_name("HP再生")
     assert_equal("hp_regen", actual)
+    actual = Vainglory::Status.convert_status_name("HP Regen")
+    assert_equal("hp_regen", actual)
+
     actual = Vainglory::Status.convert_status_name("エナジーポイント(EP)")
     assert_equal("ep", actual)
+    actual = Vainglory::Status.convert_status_name("Energy Points(EP)")
+    assert_equal("ep", actual)
+
     actual = Vainglory::Status.convert_status_name("EP回復")
     assert_equal("ep_regen", actual)
+    actual = Vainglory::Status.convert_status_name("EP Regen")
+    assert_equal("ep_regen", actual)
+
     actual = Vainglory::Status.convert_status_name("武器ダメージ")
     assert_equal("weapon_damage", actual)
+    actual = Vainglory::Status.convert_status_name("Weapon Damage")
+    assert_equal("weapon_damage", actual)
+
     actual = Vainglory::Status.convert_status_name("攻撃速度")
     assert_equal("attack_speed", actual)
+    actual = Vainglory::Status.convert_status_name("Attack Speed")
+    assert_equal("attack_speed", actual)
+
     actual = Vainglory::Status.convert_status_name("アーマー")
     assert_equal("armor", actual)
+    actual = Vainglory::Status.convert_status_name("Armor")
+    assert_equal("armor", actual)
+
     actual = Vainglory::Status.convert_status_name("シールド")
     assert_equal("shield", actual)
+    actual = Vainglory::Status.convert_status_name("Shield")
+    assert_equal("shield", actual)
+
     actual = Vainglory::Status.convert_status_name("攻撃範囲")
     assert_equal("attack_range", actual)
+    actual = Vainglory::Status.convert_status_name("Attack Range")
+    assert_equal("attack_range", actual)
+
     actual = Vainglory::Status.convert_status_name("Movement Speed")
     assert_equal("move_speed", actual)
     

--- a/test/vainglory/scrape/status_test.rb
+++ b/test/vainglory/scrape/status_test.rb
@@ -9,6 +9,9 @@ class StatusTest < Minitest::Test
     assert_equal(2, status.glow)
 
     assert_raises do
+      Vainglory::Status.new
+    end
+    assert_raises do
       Vainglory::Status.new("hp")
     end
     assert_raises do

--- a/test/vainglory/scrape/status_test.rb
+++ b/test/vainglory/scrape/status_test.rb
@@ -1,0 +1,49 @@
+require 'test_helper'
+require 'vainglory/scrape/status'
+
+class StatusTest < Minitest::Test
+  def test_initialize
+    status = Vainglory::Status.new
+    assert_nil(status.name)
+    assert_nil(status.start)
+    assert_nil(status.glow)
+
+    status = Vainglory::Status.new("hp", 100, 2)
+    assert_equal("hp", status.name)
+    assert_equal(100, status.start)
+    assert_equal(2, status.glow)
+  end
+
+  def test_convert_status_name
+    actual = Vainglory::Status.convert_status_name("ヒットポイント(HP)")
+    assert_equal("hp", actual)
+    actual = Vainglory::Status.convert_status_name("HP再生")
+    assert_equal("hp_regen", actual)
+    actual = Vainglory::Status.convert_status_name("エナジーポイント(EP)")
+    assert_equal("ep", actual)
+    actual = Vainglory::Status.convert_status_name("EP回復")
+    assert_equal("ep_regen", actual)
+    actual = Vainglory::Status.convert_status_name("武器ダメージ")
+    assert_equal("weapon_damage", actual)
+    actual = Vainglory::Status.convert_status_name("攻撃速度")
+    assert_equal("attack_speed", actual)
+    actual = Vainglory::Status.convert_status_name("アーマー")
+    assert_equal("armor", actual)
+    actual = Vainglory::Status.convert_status_name("シールド")
+    assert_equal("shield", actual)
+    actual = Vainglory::Status.convert_status_name("攻撃範囲")
+    assert_equal("attack_range", actual)
+    actual = Vainglory::Status.convert_status_name("Movement Speed")
+    assert_equal("move_speed", actual)
+    
+    actual = Vainglory::Status.convert_status_name("")
+    assert_nil(actual)
+  end
+
+  def test_to_hash
+    status = Vainglory::Status.new("hp", 100, 2)
+    actual = status.to_hash 
+    expected = {hp: {start: 100, glow: 2}}
+    assert_equal(expected, actual)
+  end
+end

--- a/test/vainglory/scrape/status_test.rb
+++ b/test/vainglory/scrape/status_test.rb
@@ -40,6 +40,8 @@ class StatusTest < Minitest::Test
     
     actual = Vainglory::Status.convert_status_name("")
     assert_nil(actual)
+    actual = Vainglory::Status.convert_status_name("ほげほげ")
+    assert_equal("ほげほげ", actual)
   end
 
   def test_to_hash


### PR DESCRIPTION
#5 の修正

現在、ハッシュのkeyは文字列ではなくシンボルになっています。
