### PR TITLE
Add method fetch specific status list in all heroes

### DIFF
--- a/data/heroes_status.yml
+++ b/data/heroes_status.yml
@@ -1,4 +1,35 @@
 ---
+:skye:
+  :hp:
+    :start: 650.0
+    :glow: 83.0
+  :hp_regen:
+    :start: 
+    :glow: 
+  :ep:
+    :start: 380.0
+    :glow: 32.0
+  :ep_regen:
+    :start: 
+    :glow: 
+  :weapon_damage:
+    :start: 63
+    :glow: 5.90909091
+  :attack_speed:
+    :start: 1
+    :glow: 0.01545455
+  :armor:
+    :start: 20
+    :glow: 6
+  :shield:
+    :start: 20
+    :glow: 6
+  :attack_range:
+    :start: 5
+    :glow: 
+  :move_speed:
+    :start: 3.1
+    :glow: 
 :rona:
   :hp:
     :start: 799.0

--- a/lib/vainglory.rb
+++ b/lib/vainglory.rb
@@ -21,6 +21,30 @@ module Vainglory
         heroes[name] = Hero.new(name.to_s, status)
       end
     end
+
+    def status(status_name, level = 12, order = :desc)
+      status_list = []
+      status_name_symbol = status_name.to_sym
+      self.heroes.each_value do |hero|
+        before_level = hero.level
+        hero.level = level
+        status_hash = {}
+        status_hash[:name] = hero.name
+        status_hash[status_name_symbol] = hero.send(status_name)
+        status_list << status_hash
+        hero.level = before_level
+      end
+
+      status_list.sort_by! do |hero|
+        hero[status_name_symbol]
+      end
+      case order
+      when :asc
+        status_list
+      when :desc
+        status_list.reverse
+      end
+    end
   end
 end
 Vainglory.init

--- a/lib/vainglory.rb
+++ b/lib/vainglory.rb
@@ -35,15 +35,20 @@ module Vainglory
         hero.level = before_level
       end
 
-      status_list.sort_by! do |hero|
-        hero[status_name_symbol]
+      status_list.sort! do |hero_a, hero_b|
+        if hero_a[status_name_symbol] == hero_b[status_name_symbol]
+          hero_a[:name] <=> hero_b[:name]
+          #hero_b[:name] <=> hero_a[:name]
+        else
+          case order
+          when :asc
+            hero_a[status_name_symbol] <=> hero_b[status_name_symbol]
+          when :desc
+            hero_b[status_name_symbol] <=> hero_a[status_name_symbol]
+          end
+        end
       end
-      case order
-      when :asc
-        status_list
-      when :desc
-        status_list.reverse
-      end
+      status_list
     end
   end
 end

--- a/test/vainglory_test.rb
+++ b/test/vainglory_test.rb
@@ -47,8 +47,8 @@ class VaingloryTest < Minitest::Test
       { name: 'krul', hp: 1501.0 },
       { name: 'koshka', hp: 1498.0 },
       { name: 'vox', hp: 1465.0 },
-      { name: 'saw', hp: 1453.0 },
       { name: 'petal', hp: 1453.0 },
+      { name: 'saw', hp: 1453.0 },
       { name: 'ringo', hp: 1405.0 },
       { name: 'celeste', hp: 1347.0 },
       { name: 'skaarf', hp: 1347.0 }
@@ -60,8 +60,8 @@ class VaingloryTest < Minitest::Test
 
     hp_list_in_all_heroes = Vainglory.status :hp, 12, :asc
     hp_list_at_level_12_in_order_asc = [
-      { name: 'skaarf', hp: 1347.0 },
       { name: 'celeste', hp: 1347.0 },
+      { name: 'skaarf', hp: 1347.0 },
       { name: 'ringo', hp: 1405.0 },
       { name: 'petal', hp: 1453.0 },
       { name: 'saw', hp: 1453.0 },
@@ -93,8 +93,8 @@ class VaingloryTest < Minitest::Test
       { name: 'fortress', hp: 986 },
       { name: 'skye', hp: 982.0 },
       { name: 'vox', hp: 975.0 },
-      { name: 'saw', hp: 956.0 },
       { name: 'petal', hp: 956.0 },
+      { name: 'saw', hp: 956.0 },
       { name: 'krul', hp: 955.0 },
       { name: 'ringo', hp: 922.0 },
       { name: 'celeste', hp: 892.0 },

--- a/test/vainglory_test.rb
+++ b/test/vainglory_test.rb
@@ -19,6 +19,7 @@ class VaingloryTest < Minitest::Test
 
   def test_set_level
     koshka = Vainglory.hero :koshka
+    koshka.level = 1
     assert_equal koshka.level, 1
     assert_equal koshka.hp, 761
     assert_equal koshka.attack_range, 1.7
@@ -26,5 +27,81 @@ class VaingloryTest < Minitest::Test
     assert_equal koshka.level, 12
     assert_equal koshka.attack_range, 1.7
     assert_equal koshka.hp, 1498
+  end
+
+  def test_fetch_hp_list_in_all_heroes
+    koshka = Vainglory.hero :koshka
+    koshka.level = 5
+
+    hp_list_in_all_heroes = Vainglory.status :hp
+    hp_list_at_level_12_in_order_desc = [
+      { name: 'glaive', hp: 2046.0 },
+      { name: 'rona', hp: 1789.0 },
+      { name: 'joule', hp: 1705.0 },
+      { name: 'adagio', hp: 1654.0 },
+      { name: 'ardan', hp: 1615.0 },
+      { name: 'skye', hp: 1563.0 },
+      { name: 'fortress', hp: 1560.0 },
+      { name: 'taka', hp: 1555.0 },
+      { name: 'catherine', hp: 1509.0 },
+      { name: 'krul', hp: 1501.0 },
+      { name: 'koshka', hp: 1498.0 },
+      { name: 'vox', hp: 1465.0 },
+      { name: 'saw', hp: 1453.0 },
+      { name: 'petal', hp: 1453.0 },
+      { name: 'ringo', hp: 1405.0 },
+      { name: 'celeste', hp: 1347.0 },
+      { name: 'skaarf', hp: 1347.0 }
+    ]
+    assert_equal hp_list_at_level_12_in_order_desc, hp_list_in_all_heroes
+
+    hp_list_in_all_heroes = Vainglory.status :hp, 12, :desc
+    assert_equal hp_list_at_level_12_in_order_desc, hp_list_in_all_heroes
+
+    hp_list_in_all_heroes = Vainglory.status :hp, 12, :asc
+    hp_list_at_level_12_in_order_asc = [
+      { name: 'skaarf', hp: 1347.0 },
+      { name: 'celeste', hp: 1347.0 },
+      { name: 'ringo', hp: 1405.0 },
+      { name: 'petal', hp: 1453.0 },
+      { name: 'saw', hp: 1453.0 },
+      { name: 'vox', hp: 1465.0 },
+      { name: 'koshka', hp: 1498.0 },
+      { name: 'krul', hp: 1501.0 },
+      { name: 'catherine', hp: 1509.0 },
+      { name: 'taka', hp: 1555.0 },
+      { name: 'fortress', hp: 1560.0 },
+      { name: 'skye', hp: 1563.0 },
+      { name: 'ardan', hp: 1615.0 },
+      { name: 'adagio', hp: 1654.0 },
+      { name: 'joule', hp: 1705.0 },
+      { name: 'rona', hp: 1789.0 },
+      { name: 'glaive', hp: 2046.0 }
+    ]
+    assert_equal hp_list_at_level_12_in_order_asc, hp_list_in_all_heroes
+
+    hp_list_in_all_heroes = Vainglory.status :hp, 5
+    hp_list_at_lelvel_5_in_order_desc = [
+      { name: 'glaive', hp: 1262.0 },
+      { name: 'rona', hp: 1159.0 },
+      { name: 'joule', hp: 1110.0 },
+      { name: 'ardan', hp: 1097.0 },
+      { name: 'adagio', hp: 1059.0 },
+      { name: 'catherine', hp: 1040.0 },
+      { name: 'taka', hp: 1037 },
+      { name: 'koshka', hp: 1029.0 },
+      { name: 'fortress', hp: 986 },
+      { name: 'skye', hp: 982.0 },
+      { name: 'vox', hp: 975.0 },
+      { name: 'saw', hp: 956.0 },
+      { name: 'petal', hp: 956.0 },
+      { name: 'krul', hp: 955.0 },
+      { name: 'ringo', hp: 922.0 },
+      { name: 'celeste', hp: 892.0 },
+      { name: 'skaarf', hp: 892.0 }
+    ]
+    assert_equal hp_list_at_lelvel_5_in_order_desc, hp_list_in_all_heroes
+
+    assert_equal koshka.level, 5
   end
 end


### PR DESCRIPTION
#12 の全ヒーローから特定のステータスの配列を取得するメソッドを追加。

`Vainglory.status :hp, 12, :desc`のように使います。
計算して求めた後はヒーローレベルを元に戻すようにしました。
