### PR TITLE
アビリティの特定項目のランキングを取得するメソッド

### DIFF
--- a/lib/vainglory.rb
+++ b/lib/vainglory.rb
@@ -59,6 +59,46 @@ module Vainglory
       end
       status_list
     end
+
+    def ability(status_name, order = :desc)
+      ability_list = []
+      status_name_symbol = status_name.to_sym
+      self.heroes.each_value do |hero|
+        hero.ability[1..3].each do |ability|
+          next if ability[status_name_symbol].nil?
+          ability_status = ability[status_name_symbol][:effect]
+          case ability_status
+          when Array
+            ability_status.each_index do |i|
+              ability_hash = {}
+              ability_hash[:name] = ability[:name]
+              ability_hash[:level] = i + 1
+              ability_hash[status_name_symbol] = ability_status[i]
+              ability_list << ability_hash
+            end
+          else
+            ability_hash = {}
+            ability_hash[:name] = ability[:name]
+            ability_hash[status_name_symbol] = ability_status
+            ability_list << ability_hash
+          end
+        end
+      end
+
+      ability_list.sort! do |ability_a, ability_b|
+        if ability_a[status_name_symbol] == ability_b[status_name_symbol]
+          ability_a[:name] <=> ability_b[:name]
+        else
+          case order
+          when :asc
+            ability_a[status_name_symbol] <=> ability_b[status_name_symbol]
+          when :desc
+            ability_b[status_name_symbol] <=> ability_a[status_name_symbol]
+          end
+        end
+      end
+      ability_list
+    end
   end
 end
 Vainglory.init

--- a/lib/vainglory.rb
+++ b/lib/vainglory.rb
@@ -22,17 +22,12 @@ module Vainglory
       end
 
       heroes_ability = YAML::load_file('data/heroes_ability.yml')
-      self.heroes.each do |self_hero_name, self_hero_value|
-        heroes_ability.each do |target_hero_name, abilities|
-          if self_hero_name == target_hero_name
-            abilities.each do |ability_name, ability_value|
-              ability = { name: ability_name.to_s }
-              # パッシブアビリティがまだ未入力のためnilか確認
-              ability.merge!(ability_value) if !ability_value.nil?
-              self_hero_value.ability << ability
-            end
-            break
-          end
+      self.heroes.each do |hero_name, hero_value|
+        heroes_ability[hero_name].each do |ability_name, ability_value|
+          ability = { name: ability_name.to_s }
+          # パッシブアビリティがまだ未入力のためnilか確認
+          ability.merge!(ability_value) if !ability_value.nil?
+          hero_value.ability << ability
         end
       end
     end

--- a/lib/vainglory.rb
+++ b/lib/vainglory.rb
@@ -23,10 +23,10 @@ module Vainglory
 
       heroes_ability = YAML::load_file('data/heroes_ability.yml')
       self.heroes.each do |hero_name, hero_value|
-        heroes_ability[hero_name].each do |ability_name, ability_value|
+        heroes_ability[hero_name].each do |ability_name, ability_status|
           ability = { name: ability_name.to_s }
           # パッシブアビリティがまだ未入力のためnilか確認
-          ability.merge!(ability_value) if !ability_value.nil?
+          ability.merge!(ability_status) if !ability_status.nil?
           hero_value.ability << ability
         end
       end

--- a/lib/vainglory.rb
+++ b/lib/vainglory.rb
@@ -53,7 +53,6 @@ module Vainglory
       status_list.sort! do |hero_a, hero_b|
         if hero_a[status_name_symbol] == hero_b[status_name_symbol]
           hero_a[:name] <=> hero_b[:name]
-          #hero_b[:name] <=> hero_a[:name]
         else
           case order
           when :asc

--- a/test/vainglory_test.rb
+++ b/test/vainglory_test.rb
@@ -111,4 +111,18 @@ class VaingloryTest < Minitest::Test
 
     assert_equal koshka.level, 5
   end
+
+  def test_fetch_ability_list_in_all_heroes
+    heighest_damage = { name: 'verse_of_judgement', level: 3, damage: 910 }
+
+    damage_list_in_all_heroes = Vainglory.ability :damage
+    assert_equal heighest_damage, damage_list_in_all_heroes[0]
+
+    damage_list_in_all_heroes = Vainglory.ability :damage, :desc
+    assert_equal heighest_damage, damage_list_in_all_heroes[0]
+
+    earliest_cool_down = { name: 'heliogenesis', level: 5, cool_down: 1 }
+    cool_down_list_in_all_heroes = Vainglory.ability :cool_down, :asc
+    assert_equal earliest_cool_down, cool_down_list_in_all_heroes[0]
+  end
 end


### PR DESCRIPTION
#17 に対応

同じアビリティ名でも、アビリティレベルが違い場合は別ハッシュになります。レベル別全アビリティから取得することになります。
